### PR TITLE
Feat/junction table preserve shared columns

### DIFF
--- a/src/decorator/options/JoinColumnOptions.ts
+++ b/src/decorator/options/JoinColumnOptions.ts
@@ -16,4 +16,12 @@ export interface JoinColumnOptions {
      * Name of the foreign key constraint.
      */
     foreignKeyConstraintName?: string
+
+    /**
+     * When set to true, prevents this column from being renamed if it appears
+     * in both joinColumns and inverseJoinColumns of a junction table.
+     * This allows shared columns for composite foreign key constraints.
+     * By default is false.
+     */
+    preserveSharedColumn?: boolean
 }

--- a/src/decorator/options/JoinTableMultipleColumnsOptions.ts
+++ b/src/decorator/options/JoinTableMultipleColumnsOptions.ts
@@ -38,4 +38,12 @@ export interface JoinTableMultipleColumnsOptions {
      * By default schema synchronization is enabled.
      */
     readonly synchronize?: boolean
+
+    /**
+     * Allows shared columns between joinColumns and inverseJoinColumns in junction table.
+     * When set to true, TypeORM will not rename duplicate column names (e.g., id_1).
+     * This is useful for partitioned junction tables where both entities share the same partition keys.
+     * By default is false.
+     */
+    preserveSharedColumns?: boolean
 }

--- a/src/decorator/relations/JoinColumn.ts
+++ b/src/decorator/relations/JoinColumn.ts
@@ -42,6 +42,7 @@ export function JoinColumn(
                 name: options.name,
                 referencedColumnName: options.referencedColumnName,
                 foreignKeyConstraintName: options.foreignKeyConstraintName,
+                preserveSharedColumn: options.preserveSharedColumn,
             } as JoinColumnMetadataArgs)
         })
     }

--- a/src/decorator/relations/JoinTable.ts
+++ b/src/decorator/relations/JoinTable.ts
@@ -51,6 +51,13 @@ export function JoinTable(
             database:
                 options && options.database ? options.database : undefined,
             synchronize: !(options && options.synchronize === false),
+            preserveSharedColumns:
+                options &&
+                (options as JoinTableMultipleColumnsOptions)
+                    .preserveSharedColumns
+                    ? (options as JoinTableMultipleColumnsOptions)
+                          .preserveSharedColumns
+                    : undefined,
         } as JoinTableMetadataArgs)
     }
 }

--- a/src/metadata-args/JoinColumnMetadataArgs.ts
+++ b/src/metadata-args/JoinColumnMetadataArgs.ts
@@ -27,4 +27,12 @@ export interface JoinColumnMetadataArgs {
      * Name of the foreign key constraint.
      */
     foreignKeyConstraintName?: string
+
+    /**
+     * When set to true, prevents this column from being renamed if it appears
+     * in both joinColumns and inverseJoinColumns of a junction table.
+     * This allows shared columns for composite foreign key constraints.
+     * By default is false.
+     */
+    preserveSharedColumn?: boolean
 }

--- a/src/metadata-args/JoinTableMetadataArgs.ts
+++ b/src/metadata-args/JoinTableMetadataArgs.ts
@@ -48,4 +48,12 @@ export interface JoinTableMetadataArgs {
      * By default schema synchronization is enabled.
      */
     readonly synchronize?: boolean
+
+    /**
+     * Allows shared columns between joinColumns and inverseJoinColumns in junction table.
+     * When set to true, TypeORM will not rename duplicate column names (e.g., id_1).
+     * This is useful for partitioned junction tables where both entities share the same partition keys.
+     * By default is false.
+     */
+    readonly preserveSharedColumns?: boolean
 }

--- a/test/github-issues/11682/entity/GroupPreserved.ts
+++ b/test/github-issues/11682/entity/GroupPreserved.ts
@@ -1,0 +1,19 @@
+import {
+    Entity,
+    PrimaryColumn,
+    ManyToMany,
+    Relation,
+} from "../../../../src/index"
+import { UserPreserved } from "./UserPreserved"
+
+@Entity()
+export class GroupPreserved {
+    @PrimaryColumn()
+    id: string
+
+    @PrimaryColumn()
+    tenantId: string
+
+    @ManyToMany(() => UserPreserved, (user) => user.groups)
+    users: Relation<UserPreserved[]>
+}

--- a/test/github-issues/11682/entity/GroupRenamed.ts
+++ b/test/github-issues/11682/entity/GroupRenamed.ts
@@ -1,0 +1,19 @@
+import {
+    Entity,
+    PrimaryColumn,
+    ManyToMany,
+    Relation,
+} from "../../../../src/index"
+import { UserRenamed } from "./UserRenamed"
+
+@Entity()
+export class GroupRenamed {
+    @PrimaryColumn()
+    id: string
+
+    @PrimaryColumn()
+    tenantId: string
+
+    @ManyToMany(() => UserRenamed, (user) => user.groups)
+    users: Relation<UserRenamed[]>
+}

--- a/test/github-issues/11682/entity/UserPreserved.ts
+++ b/test/github-issues/11682/entity/UserPreserved.ts
@@ -18,8 +18,7 @@ export class UserPreserved {
     @ManyToMany(() => GroupPreserved, (group) => group.users)
     @JoinTable({
         name: "user_groups_shared",
-        // TODO: This option doesn't exist yet - will be implemented
-        // preserveSharedColumns: true,
+        preserveSharedColumns: true, // Enable shared column preservation
         joinColumns: [
             { name: "tenant_id", referencedColumnName: "tenantId" },
             { name: "user_id", referencedColumnName: "id" },

--- a/test/github-issues/11682/entity/UserPreserved.ts
+++ b/test/github-issues/11682/entity/UserPreserved.ts
@@ -1,0 +1,34 @@
+import {
+    Entity,
+    PrimaryColumn,
+    ManyToMany,
+    JoinTable,
+    Relation,
+} from "../../../../src/index"
+import { GroupPreserved } from "./GroupPreserved"
+
+@Entity()
+export class UserPreserved {
+    @PrimaryColumn()
+    id: string
+
+    @PrimaryColumn()
+    tenantId: string
+
+    @ManyToMany(() => GroupPreserved, (group) => group.users)
+    @JoinTable({
+        name: "user_groups_shared",
+        // TODO: This option doesn't exist yet - will be implemented
+        // preserveSharedColumns: true,
+        joinColumns: [
+            { name: "tenant_id", referencedColumnName: "tenantId" },
+            { name: "user_id", referencedColumnName: "id" },
+        ],
+        inverseJoinColumns: [
+            { name: "tenant_id", referencedColumnName: "tenantId" }, // Same column - will be shared
+            { name: "group_id", referencedColumnName: "id" },
+        ],
+        synchronize: false,
+    })
+    groups: Relation<GroupPreserved[]>
+}

--- a/test/github-issues/11682/entity/UserRenamed.ts
+++ b/test/github-issues/11682/entity/UserRenamed.ts
@@ -1,0 +1,31 @@
+import {
+    Entity,
+    PrimaryColumn,
+    ManyToMany,
+    JoinTable,
+    Relation,
+} from "../../../../src/index"
+import { GroupRenamed } from "./GroupRenamed"
+
+@Entity()
+export class UserRenamed {
+    @PrimaryColumn()
+    id: string
+
+    @PrimaryColumn()
+    tenantId: string
+
+    @ManyToMany(() => GroupRenamed, (group) => group.users)
+    @JoinTable({
+        name: "user_groups",
+        joinColumns: [
+            { name: "tenant_id", referencedColumnName: "tenantId" },
+            { name: "user_id", referencedColumnName: "id" },
+        ],
+        inverseJoinColumns: [
+            { name: "tenant_id", referencedColumnName: "tenantId" }, // Same column needed for composite FK
+            { name: "group_id", referencedColumnName: "id" },
+        ],
+    })
+    groups: Relation<GroupRenamed[]>
+}

--- a/test/github-issues/11682/issue-11682.ts
+++ b/test/github-issues/11682/issue-11682.ts
@@ -1,0 +1,1067 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { UserRenamed } from "./entity/UserRenamed"
+import { GroupRenamed } from "./entity/GroupRenamed"
+import { UserPreserved } from "./entity/UserPreserved"
+import { GroupPreserved } from "./entity/GroupPreserved"
+import { MemoryLogger } from "./memory-logger"
+
+// Simple factory functions to create entities with generated IDs
+function createEntity<T extends { id: string; tenantId: string }>(
+    EntityClass: new () => T,
+    tenantId: string = "tenant1",
+): T {
+    const entity = new EntityClass()
+    entity.id = Math.random().toString(36).substring(2, 15) // Simple UUID alternative
+    entity.tenantId = tenantId
+    return entity
+}
+
+// Example usage in tests:
+// const user = createUser()
+// const group = createGroup()
+// const user2 = createUser("tenant2") // different tenant
+
+/**
+ * Support shared columns in junction tables for composite foreign keys
+ * @see https://github.com/typeorm/typeorm/issues/11682
+ */
+describe("github issues > #11682", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["sqlite", "postgres"],
+                createLogger: () => new MemoryLogger(true),
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    describe("Current behavior validation (regression tests)", () => {
+        it("should have renamed columns in junction table schema", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const userMetadata = dataSource.getMetadata(UserRenamed)
+                    const groupsRelation =
+                        userMetadata.findRelationWithPropertyPath("groups")!
+                    const junctionMetadata =
+                        groupsRelation.junctionEntityMetadata!
+
+                    const columnNames = junctionMetadata.columns.map(
+                        (col) => col.databaseName,
+                    )
+
+                    // Should have 4 columns
+                    expect(columnNames).to.have.length(4)
+
+                    // Should contain user_id, group_id and tenant_id renamed
+                    expect(columnNames).to.include("user_id")
+                    expect(columnNames).to.include("group_id")
+                    expect(columnNames).to.include("tenant_id_1")
+                    expect(columnNames).to.include("tenant_id_2")
+                }),
+            ))
+
+        describe("from owner side", () => {
+            it("should generate INSERT with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserRenamed)
+                        await dataSource.manager.save(user)
+
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction INSERT
+                        logger.clear()
+
+                        user.groups = [group]
+                        await dataSource.manager.save(user)
+
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups"),
+                        )
+
+                        expect(insertQueries).to.have.length(1)
+
+                        const insertQuery = insertQueries[0]
+
+                        // Parse INSERT column names using regex
+                        const insertRegex =
+                            /INSERT INTO "user_groups"\("(\w+)", "(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const match = insertQuery.match(insertRegex)
+                        const columns = [
+                            match![1],
+                            match![2],
+                            match![3],
+                            match![4],
+                        ]
+
+                        // Validate we have exactly the expected columns
+                        expect(columns).to.have.length(4)
+                        expect(columns).to.include("user_id")
+                        expect(columns).to.include("group_id")
+                        expect(columns).to.include("tenant_id_1")
+                        expect(columns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should generate DELETE with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data with existing relationship
+                        const user = createEntity(UserRenamed)
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save([user, group])
+
+                        user.groups = [group]
+                        await dataSource.manager.save(user)
+
+                        // Clear setup queries and test junction DELETE
+                        logger.clear()
+
+                        user.groups = []
+                        await dataSource.manager.save(user)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups"),
+                        )
+
+                        expect(deleteQueries).to.have.length(1)
+
+                        const deleteQuery = deleteQueries[0]
+
+                        // Parse DELETE WHERE clause using regex
+                        const deleteRegex =
+                            /WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/s
+
+                        const match = deleteQuery.match(deleteRegex)
+                        const whereColumns = [
+                            match![1],
+                            match![2],
+                            match![3],
+                            match![4],
+                        ]
+
+                        // Validate WHERE clause uses renamed columns
+                        expect(whereColumns).to.have.length(4)
+                        expect(whereColumns).to.include("user_id")
+                        expect(whereColumns).to.include("group_id")
+                        expect(whereColumns).to.include("tenant_id_1")
+                        expect(whereColumns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should generate UPDATE operations (DELETE + INSERT)", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserRenamed)
+                        const group1 = createEntity(GroupRenamed)
+                        const group2 = createEntity(GroupRenamed)
+                        await dataSource.manager.save([user, group1, group2])
+
+                        // Establish initial relationship
+                        user.groups = [group1]
+                        await dataSource.manager.save(user)
+
+                        // Clear setup queries and test relationship update
+                        logger.clear()
+
+                        user.groups = [group2] // Change from group1 to group2
+                        await dataSource.manager.save(user)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups"),
+                        )
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups"),
+                        )
+
+                        // Should perform DELETE (remove old) + INSERT (add new)
+                        expect(deleteQueries).to.have.length(1)
+                        expect(insertQueries).to.have.length(1)
+
+                        // Parse DELETE query
+                        const deleteQuery = deleteQueries[0]
+                        const deleteRegex =
+                            /DELETE FROM "user_groups" WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/
+
+                        const deleteMatch = deleteQuery.match(deleteRegex)
+                        const deleteColumns = [
+                            deleteMatch![1],
+                            deleteMatch![2],
+                            deleteMatch![3],
+                            deleteMatch![4],
+                        ]
+
+                        expect(deleteColumns).to.include("user_id")
+                        expect(deleteColumns).to.include("group_id")
+                        expect(deleteColumns).to.include("tenant_id_1")
+                        expect(deleteColumns).to.include("tenant_id_2")
+
+                        // Parse INSERT query
+                        const insertQuery = insertQueries[0]
+                        const insertRegex =
+                            /INSERT INTO "user_groups"\("(\w+)", "(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const insertMatch = insertQuery.match(insertRegex)
+                        const insertColumns = [
+                            insertMatch![1],
+                            insertMatch![2],
+                            insertMatch![3],
+                            insertMatch![4],
+                        ]
+
+                        expect(insertColumns).to.include("user_id")
+                        expect(insertColumns).to.include("group_id")
+                        expect(insertColumns).to.include("tenant_id_1")
+                        expect(insertColumns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should work functionally with column renaming", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const user = createEntity(UserRenamed)
+                        const group1 = createEntity(GroupRenamed)
+                        const group2 = createEntity(GroupRenamed)
+
+                        await dataSource.manager.save([user, group1, group2])
+
+                        // Test adding relationships
+                        user.groups = [group1, group2]
+                        await dataSource.manager.save(user)
+
+                        let savedUser = await dataSource.manager.findOne(
+                            UserRenamed,
+                            {
+                                where: { id: user.id, tenantId: user.tenantId },
+                                relations: ["groups"],
+                            },
+                        )
+
+                        expect(savedUser?.groups).to.have.length(2)
+
+                        // Test updating relationships
+                        user.groups = [group1]
+                        await dataSource.manager.save(user)
+
+                        savedUser = await dataSource.manager.findOne(
+                            UserRenamed,
+                            {
+                                where: { id: user.id, tenantId: user.tenantId },
+                                relations: ["groups"],
+                            },
+                        )
+
+                        expect(savedUser?.groups).to.have.length(1)
+                        expect(savedUser?.groups[0].id).to.equal(group1.id)
+                    }),
+                ))
+        })
+
+        describe("from inverse side", () => {
+            it("should generate INSERT with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserRenamed)
+                        await dataSource.manager.save(user)
+
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction INSERT
+                        logger.clear()
+
+                        group.users = [user]
+                        await dataSource.manager.save(group)
+
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups"),
+                        )
+
+                        expect(insertQueries).to.have.length(1)
+
+                        const insertQuery = insertQueries[0]
+
+                        // Parse INSERT column names using regex
+                        const insertRegex =
+                            /INSERT INTO "user_groups"\("(\w+)", "(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const match = insertQuery.match(insertRegex)
+                        const columns = [
+                            match![1],
+                            match![2],
+                            match![3],
+                            match![4],
+                        ]
+
+                        // Validate we have exactly the expected columns
+                        expect(columns).to.have.length(4)
+                        expect(columns).to.include("user_id")
+                        expect(columns).to.include("group_id")
+                        expect(columns).to.include("tenant_id_1")
+                        expect(columns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should generate DELETE with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data with existing relationship
+                        const user = createEntity(UserRenamed)
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save([user, group])
+
+                        group.users = [user]
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction DELETE
+                        logger.clear()
+
+                        group.users = []
+                        await dataSource.manager.save(group)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups"),
+                        )
+
+                        expect(deleteQueries).to.have.length(1)
+
+                        const deleteQuery = deleteQueries[0]
+
+                        // Parse DELETE WHERE clause using regex
+                        const deleteRegex =
+                            /WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/s
+
+                        const match = deleteQuery.match(deleteRegex)
+                        const whereColumns = [
+                            match![1],
+                            match![2],
+                            match![3],
+                            match![4],
+                        ]
+
+                        // Validate WHERE clause uses renamed columns
+                        expect(whereColumns).to.have.length(4)
+                        expect(whereColumns).to.include("user_id")
+                        expect(whereColumns).to.include("group_id")
+                        expect(whereColumns).to.include("tenant_id_1")
+                        expect(whereColumns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should generate UPDATE operations (DELETE + INSERT)", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user1 = createEntity(UserRenamed)
+                        const user2 = createEntity(UserRenamed)
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save([user1, user2, group])
+
+                        // Establish initial relationship
+                        group.users = [user1]
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test relationship update
+                        logger.clear()
+
+                        group.users = [user2] // Change from user1 to user2
+                        await dataSource.manager.save(group)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups"),
+                        )
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups"),
+                        )
+
+                        // Should perform DELETE (remove old) + INSERT (add new)
+                        expect(deleteQueries).to.have.length(1)
+                        expect(insertQueries).to.have.length(1)
+
+                        // Parse DELETE query
+                        const deleteQuery = deleteQueries[0]
+                        const deleteRegex =
+                            /DELETE FROM "user_groups" WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/
+
+                        const deleteMatch = deleteQuery.match(deleteRegex)
+                        const deleteColumns = [
+                            deleteMatch![1],
+                            deleteMatch![2],
+                            deleteMatch![3],
+                            deleteMatch![4],
+                        ]
+
+                        expect(deleteColumns).to.include("user_id")
+                        expect(deleteColumns).to.include("group_id")
+                        expect(deleteColumns).to.include("tenant_id_1")
+                        expect(deleteColumns).to.include("tenant_id_2")
+
+                        // Parse INSERT query
+                        const insertQuery = insertQueries[0]
+                        const insertRegex =
+                            /INSERT INTO "user_groups"\("(\w+)", "(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const insertMatch = insertQuery.match(insertRegex)
+                        const insertColumns = [
+                            insertMatch![1],
+                            insertMatch![2],
+                            insertMatch![3],
+                            insertMatch![4],
+                        ]
+
+                        expect(insertColumns).to.include("user_id")
+                        expect(insertColumns).to.include("group_id")
+                        expect(insertColumns).to.include("tenant_id_1")
+                        expect(insertColumns).to.include("tenant_id_2")
+                    }),
+                ))
+
+            it("should work functionally with column renaming", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const user1 = createEntity(UserRenamed)
+                        const user2 = createEntity(UserRenamed)
+                        const group = createEntity(GroupRenamed)
+                        await dataSource.manager.save([user1, user2, group])
+
+                        // Test adding relationships
+                        group.users = [user1, user2]
+                        await dataSource.manager.save(group)
+
+                        let savedGroup = await dataSource.manager.findOne(
+                            GroupRenamed,
+                            {
+                                where: {
+                                    id: group.id,
+                                    tenantId: group.tenantId,
+                                },
+                                relations: ["users"],
+                            },
+                        )
+
+                        expect(savedGroup?.users).to.have.length(2)
+
+                        // Test updating relationships
+                        group.users = [user1]
+                        await dataSource.manager.save(group)
+
+                        savedGroup = await dataSource.manager.findOne(
+                            GroupRenamed,
+                            {
+                                where: {
+                                    id: group.id,
+                                    tenantId: group.tenantId,
+                                },
+                                relations: ["users"],
+                            },
+                        )
+
+                        expect(savedGroup?.users).to.have.length(1)
+                        expect(savedGroup?.users[0].id).to.equal(user1.id)
+                    }),
+                ))
+        })
+
+        it("should maintain bidirectional consistency", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = createEntity(UserRenamed)
+                    const group1 = createEntity(GroupRenamed)
+                    const group2 = createEntity(GroupRenamed)
+                    await dataSource.manager.save([user, group1, group2])
+
+                    // Set relationship from owner side
+                    user.groups = [group1]
+                    await dataSource.manager.save(user)
+
+                    // Verify from inverse side
+                    let savedGroup1 = await dataSource.manager.findOneOrFail(
+                        GroupRenamed,
+                        {
+                            where: { id: group1.id, tenantId: group1.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup1.users).to.have.length(1)
+                    expect(savedGroup1.users[0].id).to.equal(user.id)
+
+                    // Change relationship from inverse side (add user to group2)
+                    group2.users = [user]
+                    await dataSource.manager.save(group2)
+
+                    // Verify consistency from owner side
+                    const savedUser = await dataSource.manager.findOneOrFail(
+                        UserRenamed,
+                        {
+                            where: { id: user.id, tenantId: user.tenantId },
+                            relations: ["groups"],
+                        },
+                    )
+                    expect(savedUser.groups).to.have.length(2)
+                    const groupIds = savedUser.groups.map((g) => g.id)
+                    expect(groupIds).to.include(group1.id)
+                    expect(groupIds).to.include(group2.id)
+
+                    // Verify group1 still has the user (relationship is additive)
+                    savedGroup1 = await dataSource.manager.findOneOrFail(
+                        GroupRenamed,
+                        {
+                            where: { id: group1.id, tenantId: group1.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup1.users).to.have.length(1)
+                    expect(savedGroup1.users[0].id).to.equal(user.id)
+
+                    // Verify group2 also has the user
+                    const savedGroup2 = await dataSource.manager.findOneOrFail(
+                        GroupRenamed,
+                        {
+                            where: { id: group2.id, tenantId: group2.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup2.users).to.have.length(1)
+                    expect(savedGroup2.users[0].id).to.equal(user.id)
+                }),
+            ))
+    })
+
+    describe("Expected behavior with preserveSharedColumns", () => {
+        it("should have preserved shared columns in junction table schema", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const userMetadata = dataSource.getMetadata(UserPreserved)
+                    const groupsRelation =
+                        userMetadata.findRelationWithPropertyPath("groups")!
+                    const junctionMetadata =
+                        groupsRelation.junctionEntityMetadata!
+
+                    const columnNames = junctionMetadata.columns.map(
+                        (col) => col.databaseName,
+                    )
+
+                    // Should still have 4 columns
+                    expect(columnNames).to.have.length(4)
+
+                    // Should contain user_id, group_id and tenant_id
+                    expect(columnNames).to.include("user_id")
+                    expect(columnNames).to.include("group_id")
+                    expect(columnNames).to.include("tenant_id") // Found twice
+                }),
+            ))
+
+        describe("from owner side", () => {
+            it("should generate INSERT with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserPreserved)
+                        await dataSource.manager.save(user)
+
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction INSERT
+                        logger.clear()
+
+                        user.groups = [group]
+                        await dataSource.manager.save(user)
+
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        expect(insertQueries).to.have.length(1)
+
+                        const insertQuery = insertQueries[0]
+
+                        // Parse INSERT column names using regex
+                        const insertRegex =
+                            /INSERT INTO "user_groups_shared"\("(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const match = insertQuery.match(insertRegex)
+                        const columns = [match![1], match![2], match![3]]
+
+                        // Validate we have exactly the expected columns
+                        expect(columns).to.have.length(3)
+                        expect(columns).to.include("user_id")
+                        expect(columns).to.include("group_id")
+                        expect(columns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should generate DELETE with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data with existing relationship
+                        const user = createEntity(UserPreserved)
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save([user, group])
+
+                        user.groups = [group]
+                        await dataSource.manager.save(user)
+
+                        // Clear setup queries and test junction DELETE
+                        logger.clear()
+
+                        user.groups = []
+                        await dataSource.manager.save(user)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        expect(deleteQueries).to.have.length(1)
+
+                        const deleteQuery = deleteQueries[0]
+
+                        // Parse DELETE WHERE clause using regex
+                        const deleteRegex =
+                            /WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/s
+
+                        const match = deleteQuery.match(deleteRegex)
+                        const whereColumns = [match![1], match![2], match![3]]
+
+                        // Validate WHERE clause uses renamed columns
+                        expect(whereColumns).to.have.length(3)
+                        expect(whereColumns).to.include("user_id")
+                        expect(whereColumns).to.include("group_id")
+                        expect(whereColumns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should generate UPDATE operations (DELETE + INSERT)", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserPreserved)
+                        const group1 = createEntity(GroupPreserved)
+                        const group2 = createEntity(GroupPreserved)
+                        await dataSource.manager.save([user, group1, group2])
+
+                        // Establish initial relationship
+                        user.groups = [group1]
+                        await dataSource.manager.save(user)
+
+                        // Clear setup queries and test relationship update
+                        logger.clear()
+
+                        user.groups = [group2] // Change from group1 to group2
+                        await dataSource.manager.save(user)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups_shared"),
+                        )
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        // Should perform DELETE (remove old) + INSERT (add new)
+                        expect(deleteQueries).to.have.length(1)
+                        expect(insertQueries).to.have.length(1)
+
+                        // Parse DELETE query
+                        const deleteQuery = deleteQueries[0]
+                        const deleteRegex =
+                            /DELETE FROM "user_groups_shared" WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/
+
+                        const deleteMatch = deleteQuery.match(deleteRegex)
+                        const deleteColumns = [
+                            deleteMatch![1],
+                            deleteMatch![2],
+                            deleteMatch![3],
+                        ]
+
+                        expect(deleteColumns).to.include("user_id")
+                        expect(deleteColumns).to.include("group_id")
+                        expect(deleteColumns).to.include("tenant_id")
+
+                        // Parse INSERT query
+                        const insertQuery = insertQueries[0]
+                        const insertRegex =
+                            /INSERT INTO "user_groups_shared"\("(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const insertMatch = insertQuery.match(insertRegex)
+                        const insertColumns = [
+                            insertMatch![1],
+                            insertMatch![2],
+                            insertMatch![3],
+                        ]
+
+                        expect(insertColumns).to.include("user_id")
+                        expect(insertColumns).to.include("group_id")
+                        expect(insertColumns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should work functionally with column renaming", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const user = createEntity(UserPreserved)
+                        const group1 = createEntity(GroupPreserved)
+                        const group2 = createEntity(GroupPreserved)
+
+                        await dataSource.manager.save([user, group1, group2])
+
+                        // Test adding relationships
+                        user.groups = [group1, group2]
+                        await dataSource.manager.save(user)
+
+                        let savedUser = await dataSource.manager.findOne(
+                            UserPreserved,
+                            {
+                                where: { id: user.id, tenantId: user.tenantId },
+                                relations: ["groups"],
+                            },
+                        )
+
+                        expect(savedUser?.groups).to.have.length(2)
+
+                        // Test updating relationships
+                        user.groups = [group1]
+                        await dataSource.manager.save(user)
+
+                        savedUser = await dataSource.manager.findOne(
+                            UserPreserved,
+                            {
+                                where: { id: user.id, tenantId: user.tenantId },
+                                relations: ["groups"],
+                            },
+                        )
+
+                        expect(savedUser?.groups).to.have.length(1)
+                        expect(savedUser?.groups[0].id).to.equal(group1.id)
+                    }),
+                ))
+        })
+
+        describe("from inverse side", () => {
+            it("should generate INSERT with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user = createEntity(UserPreserved)
+                        await dataSource.manager.save(user)
+
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction INSERT
+                        logger.clear()
+
+                        group.users = [user]
+                        await dataSource.manager.save(group)
+
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        expect(insertQueries).to.have.length(1)
+
+                        const insertQuery = insertQueries[0]
+
+                        // Parse INSERT column names using regex
+                        const insertRegex =
+                            /INSERT INTO "user_groups_shared"\("(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const match = insertQuery.match(insertRegex)
+                        const columns = [match![1], match![2], match![3]]
+
+                        // Validate we have exactly the expected columns
+                        expect(columns).to.have.length(3)
+                        expect(columns).to.include("user_id")
+                        expect(columns).to.include("group_id")
+                        expect(columns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should generate DELETE with renamed columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data with existing relationship
+                        const user = createEntity(UserPreserved)
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save([user, group])
+
+                        group.users = [user]
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test junction DELETE
+                        logger.clear()
+
+                        group.users = []
+                        await dataSource.manager.save(group)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        expect(deleteQueries).to.have.length(1)
+
+                        const deleteQuery = deleteQueries[0]
+
+                        // Parse DELETE WHERE clause using regex
+                        const deleteRegex =
+                            /WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/s
+
+                        const match = deleteQuery.match(deleteRegex)
+                        const whereColumns = [match![1], match![2], match![3]]
+
+                        // Validate WHERE clause uses renamed columns
+                        expect(whereColumns).to.have.length(3)
+                        expect(whereColumns).to.include("user_id")
+                        expect(whereColumns).to.include("group_id")
+                        expect(whereColumns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should generate UPDATE operations (DELETE + INSERT)", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const logger = dataSource.logger as MemoryLogger
+
+                        // Setup test data
+                        const user1 = createEntity(UserPreserved)
+                        const user2 = createEntity(UserPreserved)
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save([user1, user2, group])
+
+                        // Establish initial relationship
+                        group.users = [user1]
+                        await dataSource.manager.save(group)
+
+                        // Clear setup queries and test relationship update
+                        logger.clear()
+
+                        group.users = [user2] // Change from user1 to user2
+                        await dataSource.manager.save(group)
+
+                        const deleteQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("DELETE") &&
+                                q.includes("user_groups_shared"),
+                        )
+                        const insertQueries = logger.queries.filter(
+                            (q) =>
+                                q.includes("INSERT") &&
+                                q.includes("user_groups_shared"),
+                        )
+
+                        // Should perform DELETE (remove old) + INSERT (add new)
+                        expect(deleteQueries).to.have.length(1)
+                        expect(insertQueries).to.have.length(1)
+
+                        // Parse DELETE query
+                        const deleteQuery = deleteQueries[0]
+                        const deleteRegex =
+                            /DELETE FROM "user_groups_shared" WHERE \("(\w+)" = .+ AND "(\w+)" = .+ AND "(\w+)" = .+\)/
+
+                        const deleteMatch = deleteQuery.match(deleteRegex)
+                        const deleteColumns = [
+                            deleteMatch![1],
+                            deleteMatch![2],
+                            deleteMatch![3],
+                        ]
+
+                        expect(deleteColumns).to.include("user_id")
+                        expect(deleteColumns).to.include("group_id")
+                        expect(deleteColumns).to.include("tenant_id")
+
+                        // Parse INSERT query
+                        const insertQuery = insertQueries[0]
+                        const insertRegex =
+                            /INSERT INTO "user_groups_shared"\("(\w+)", "(\w+)", "(\w+)"\)/
+
+                        const insertMatch = insertQuery.match(insertRegex)
+                        const insertColumns = [
+                            insertMatch![1],
+                            insertMatch![2],
+                            insertMatch![3],
+                        ]
+
+                        expect(insertColumns).to.include("user_id")
+                        expect(insertColumns).to.include("group_id")
+                        expect(insertColumns).to.include("tenant_id")
+                    }),
+                ))
+
+            it("should work functionally with column renaming", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const user1 = createEntity(UserPreserved)
+                        const user2 = createEntity(UserPreserved)
+                        const group = createEntity(GroupPreserved)
+                        await dataSource.manager.save([user1, user2, group])
+
+                        // Test adding relationships
+                        group.users = [user1, user2]
+                        await dataSource.manager.save(group)
+
+                        let savedGroup = await dataSource.manager.findOne(
+                            GroupPreserved,
+                            {
+                                where: {
+                                    id: group.id,
+                                    tenantId: group.tenantId,
+                                },
+                                relations: ["users"],
+                            },
+                        )
+
+                        expect(savedGroup?.users).to.have.length(2)
+
+                        // Test updating relationships
+                        group.users = [user1]
+                        await dataSource.manager.save(group)
+
+                        savedGroup = await dataSource.manager.findOne(
+                            GroupPreserved,
+                            {
+                                where: {
+                                    id: group.id,
+                                    tenantId: group.tenantId,
+                                },
+                                relations: ["users"],
+                            },
+                        )
+
+                        expect(savedGroup?.users).to.have.length(1)
+                        expect(savedGroup?.users[0].id).to.equal(user1.id)
+                    }),
+                ))
+        })
+
+        it("should maintain bidirectional consistency", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = createEntity(UserPreserved)
+                    const group1 = createEntity(GroupPreserved)
+                    const group2 = createEntity(GroupPreserved)
+                    await dataSource.manager.save([user, group1, group2])
+
+                    // Set relationship from owner side
+                    user.groups = [group1]
+                    await dataSource.manager.save(user)
+
+                    // Verify from inverse side
+                    let savedGroup1 = await dataSource.manager.findOneOrFail(
+                        GroupPreserved,
+                        {
+                            where: { id: group1.id, tenantId: group1.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup1.users).to.have.length(1)
+                    expect(savedGroup1.users[0].id).to.equal(user.id)
+
+                    // Change relationship from inverse side (add user to group2)
+                    group2.users = [user]
+                    await dataSource.manager.save(group2)
+
+                    // Verify consistency from owner side
+                    const savedUser = await dataSource.manager.findOneOrFail(
+                        UserPreserved,
+                        {
+                            where: { id: user.id, tenantId: user.tenantId },
+                            relations: ["groups"],
+                        },
+                    )
+                    expect(savedUser.groups).to.have.length(2)
+                    const groupIds = savedUser.groups.map((g) => g.id)
+                    expect(groupIds).to.include(group1.id)
+                    expect(groupIds).to.include(group2.id)
+
+                    // Verify group1 still has the user (relationship is additive)
+                    savedGroup1 = await dataSource.manager.findOneOrFail(
+                        GroupPreserved,
+                        {
+                            where: { id: group1.id, tenantId: group1.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup1.users).to.have.length(1)
+                    expect(savedGroup1.users[0].id).to.equal(user.id)
+
+                    // Verify group2 also has the user
+                    const savedGroup2 = await dataSource.manager.findOneOrFail(
+                        GroupPreserved,
+                        {
+                            where: { id: group2.id, tenantId: group2.tenantId },
+                            relations: ["users"],
+                        },
+                    )
+                    expect(savedGroup2.users).to.have.length(1)
+                    expect(savedGroup2.users[0].id).to.equal(user.id)
+                }),
+            ))
+    })
+})

--- a/test/github-issues/11682/memory-logger.ts
+++ b/test/github-issues/11682/memory-logger.ts
@@ -1,0 +1,30 @@
+import { Logger } from "../../../src/logger/Logger"
+
+export class MemoryLogger implements Logger {
+    constructor(public enabled = true) {}
+
+    private _queries: string[] = []
+    get queries() {
+        return this._queries
+    }
+
+    logQuery(query: string) {
+        if (this.enabled) {
+            this._queries.push(query)
+        }
+    }
+
+    logQueryError(error: string, query: string) {}
+
+    logQuerySlow(time: number, query: string) {}
+
+    logSchemaBuild(message: string) {}
+
+    logMigration(message: string) {}
+
+    log(level: "log" | "info" | "warn", message: any) {}
+
+    clear() {
+        this._queries = []
+    }
+}


### PR DESCRIPTION
### Description of change

This pull request implements **shared column preservation for junction tables in composite foreign key scenarios**, addressing issue [#11682](https://github.com/typeorm/typeorm/issues/11682).

**Problem Solved:**
Currently, TypeORM automatically renames columns that appear in both `joinColumns` and `inverseJoinColumns` to avoid duplicates (e.g., `tenant_id` → `tenant_id_1`, `tenant_id_2`). This prevents composite foreign key constraints in partitioned many-to-many relationships.

**Solution Implemented:**
Adds configuration options to preserve shared columns:

```typescript
@JoinTable({
    name: "user_groups_shared",
    preserveSharedColumns: true, // Table-level option
    joinColumns: [
        { name: "tenant_id", referencedColumnName: "tenantId" },
        { name: "user_id", referencedColumnName: "id" },
    ],
    inverseJoinColumns: [
        { name: "tenant_id", referencedColumnName: "tenantId", preserveSharedColumn: true }, // Column-level option
        { name: "group_id", referencedColumnName: "id" },
    ],
})
```

**Technical Implementation:**
- Pre-calculates shared columns during metadata building
- Skips renaming for marked shared columns  
- Marks inverse-side shared columns as non-insertable/updatable to prevent duplicate column SQL errors
- Maintains backward compatibility (defaults to false)

**Generated DML/DQL:**
```sql
-- With preserveSharedColumns: true
INSERT INTO "user_groups_shared"("tenant_id", "user_id", "group_id") VALUES ($1, $2, $3);

-- Current behavior
INSERT INTO "user_groups"("tenant_id_1", "user_id", "tenant_id_2", "group_id") VALUES ($1, $2, $3, $4);
```


**Current Scope - DML/DQL Focus:**
This implementation primarily addresses the **immediate pain point** described in [issue #11682](https://github.com/typeorm/typeorm/issues/11682): the inability to use TypeORM's DML/DQL operations with user-created partitioned junction tables.

The main problem users face today is that when they manually create partitioned junction tables with shared columns (which TypeORM currently cannot create), TypeORM's column renaming logic generates incorrect INSERT/UPDATE/DELETE statements that don't match the actual table schema.

This feature solves that core issue by allowing TypeORM to generate correct DML/DQL statements for existing tables with shared columns. 

**DDL Considerations:**
While DDL operations (table creation) are not addressed in this implementation, they remain an important consideration for future enhancements. For now, users must create junction tables manually when using partitioned tables or composite foreign key constraints.

The junction table must be created manually like:
```sql
CREATE TABLE "user_groups" (
    "tenant_id" varchar NOT NULL,  -- Shared column for both FKs
    "user_id" varchar NOT NULL,
    "group_id" varchar NOT NULL,
    PRIMARY KEY ("tenant_id", "user_id", "group_id"),
    FOREIGN KEY ("tenant_id", "user_id") REFERENCES "user"("tenant_id", "id"),
    FOREIGN KEY ("tenant_id", "group_id") REFERENCES "group"("tenant_id", "id")
) PARTITION BY HASH ("tenant_id");
```

This feature ensures TypeORM can then properly interact with such manually-created tables through correct DML/DQL generation.

### How this change was verified

**Comprehensive Test Suite (20 tests passing):**
- Regression tests for existing column renaming behavior
- New feature tests for shared column preservation  
- SQL generation validation for INSERT/DELETE/UPDATE operations
- Functional relationship management from both owner and inverse sides
- Cross-driver testing (SQLite and PostgreSQL)

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #11682`
- [x] There are new or updated unit tests validating the change (20 comprehensive tests)
- [x] Documentation has been updated to reflect this change (JSDoc comments on new options)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added option to preserve shared columns in many-to-many join tables, preventing automatic renaming of duplicate column names.
  - New flags on relation decorators/options enable shared columns for composite foreign keys.
  - More resilient relation mapping when only foreign key values are present, improving persistence and query behavior.

- Tests
  - Introduced comprehensive scenarios validating shared-column behavior across databases.
  - Added an in-memory query logger utility for test assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->